### PR TITLE
Support rsyslog.d fragments

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,36 @@ Wheter to send logs remotely to a centralized logging service.
 
 - *Default*: 'false'
 
+rsyslog_d_dir
+-------------
+Path to place rsyslog.d files.
+
+- *Default*: '/etc/rsyslog.d'
+
+rsyslog_d_dir_owner
+-------------------
+Owner of the rsyslog.d directory.
+
+- *Default*: 'root'
+
+rsyslog_d_dir_group
+-------------------
+Group of the rsyslog.d directory.
+
+- *Default*: 'root'
+
+rsyslog_d_dir_mode
+------------------
+Mode of the rsyslog.d directory.
+
+- *Default*: '0755'
+
+rsyslog_fragments
+-----------------
+Hash of fragments to pass to rsyslog::fragment
+
+- *Default*: undef
+
 spool_dir
 ---------
 Path to place spool files.
@@ -227,3 +257,22 @@ source_facilities
 List of source facilities to be sent to remote log server. Only used if remote_logging is true.
 
 - *Default*: `*.*`
+
+===
+
+# rsyslog::fragment define #
+Places a fragment in $rsyslog_d_dir directory
+
+## Parameters for rsyslog::fragment
+
+ensure
+------
+Whether the file should exist or not. Possible values are file, present and absent.
+
+- *Default*: 'file'
+
+content
+-------
+String with contents of the fragment file.
+
+- *Default*: undef

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -1,0 +1,24 @@
+# == Class: rsyslog::fragment
+#
+# Places a fragment in $rsyslog_d_dir directory
+#
+define rsyslog::fragment (
+  $ensure  = 'file',
+  $content = undef,
+) {
+
+  include rsyslog
+
+  validate_re($ensure, ['file','present','absent'])
+  validate_string($content)
+
+  file { "${rsyslog::rsyslog_d_dir}/${name}.conf":
+    ensure  => $ensure,
+    content => $content,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    require => Common::Mkdir_p[$rsyslog::rsyslog_d_dir],
+    notify  => Service['rsyslog_daemon'],
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,11 @@ class rsyslog (
   $log_dir                  = '/srv/logs',
   $remote_template          = '%HOSTNAME%/%$YEAR%-%$MONTH%-%$DAY%.log',
   $remote_logging           = 'false',
+  $rsyslog_d_dir            = '/etc/rsyslog.d',
+  $rsyslog_d_dir_owner      = 'root',
+  $rsyslog_d_dir_group      = 'root',
+  $rsyslog_d_dir_mode       = '0755',
+  $rsyslog_fragments        = undef,
   $spool_dir                = '/var/spool/rsyslog',
   $spool_dir_owner          = 'root',
   $spool_dir_group          = 'root',
@@ -46,6 +51,12 @@ class rsyslog (
   if $source_facilities == '' {
     fail('rsyslog::source_facilities cannot be empty!')
   }
+
+  if $rsyslog_fragments != undef {
+    create_resources('rsyslog::fragment', $rsyslog_fragments)
+  }
+
+  validate_absolute_path($rsyslog_d_dir)
 
   case $::osfamily {
     'RedHat': {
@@ -194,6 +205,17 @@ class rsyslog (
     mode    => $sysconfig_mode,
     require => Package[$package],
     notify  => Service['rsyslog_daemon'],
+  }
+
+  common::mkdir_p { $rsyslog_d_dir: }
+
+  file { 'rsyslog_d_dir':
+    ensure  => 'directory',
+    path    => $rsyslog_d_dir,
+    owner   => $rsyslog_d_dir_owner,
+    group   => $rsyslog_d_dir_group,
+    mode    => $rsyslog_d_dir_mode,
+    require => Common::Mkdir_p[$rsyslog_d_dir],
   }
 
   service { 'rsyslog_daemon':

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -491,6 +491,68 @@ describe 'rsyslog' do
     end
   end
 
+  describe 'rsyslog_d_dir' do
+    context "with default params" do
+      let :facts do
+        {
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '6',
+        }
+      end
+      it {
+        should contain_file('rsyslog_d_dir').with({
+          'ensure'  => 'directory',
+          'path'    => '/etc/rsyslog.d',
+          'owner'   => 'root',
+          'group'   => 'root',
+          'mode'    => '0755',
+          'require' => 'Common::Mkdir_p[/etc/rsyslog.d]',
+        })
+      }
+    end
+
+    context "with rsyslog_d_dir parameters specified" do
+      let :facts do
+        {
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '6',
+        }
+      end
+      let :params do
+        { :rsyslog_d_dir       => '/custom/rsyslog.d',
+          :rsyslog_d_dir_owner => 'other',
+          :rsyslog_d_dir_group => 'othergroup',
+          :rsyslog_d_dir_mode  => '0775',
+        }
+      end
+      it {
+        should contain_file('rsyslog_d_dir').with({
+          'ensure'  => 'directory',
+          'path'    => '/custom/rsyslog.d',
+          'owner'   => 'other',
+          'group'   => 'othergroup',
+          'mode'    => '0775',
+          'require' => 'Common::Mkdir_p[/custom/rsyslog.d]',
+        })
+      }
+    end
+
+    context "with rsyslog_d_dir specified as invalid path" do
+      let :facts do
+        {
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '6',
+        }
+      end
+      let (:params) { { :rsyslog_d_dir => 'custom/rsyslog.d' } }
+      it 'should fail' do
+        expect {
+          should contain_class('rsyslog')
+        }.to raise_error(Puppet::Error)
+      end
+    end
+  end
+
   describe 'case is_log_server, default params' do
     let :facts do
       {

--- a/spec/defines/fragment_spec.rb
+++ b/spec/defines/fragment_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+describe 'rsyslog::fragment' do
+
+  context 'create file from content' do
+    let(:title) { 'example' }
+    let(:params) {
+      { :content => '# ### begin forwarding rule ###
+# Example rule
+# ### end of the forwarding rule ###'
+      }
+    }
+    let(:facts) {
+      {
+        :osfamily          => 'RedHat',
+        :lsbmajdistrelease => '5',
+      }
+    }
+
+    it { should contain_class('rsyslog') }
+
+    it {
+      should contain_file('/etc/rsyslog.d/example.conf').with({
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'Common::Mkdir_p[/etc/rsyslog.d]',
+      })
+    }
+    it { should contain_file('/etc/rsyslog.d/example.conf').with_content(
+%{# ### begin forwarding rule ###
+# Example rule
+# ### end of the forwarding rule ###})
+    }
+  end
+
+  context 'with content specified as invalid string' do
+    let(:title) { 'example' }
+    let(:facts) {
+      { :osfamily          => 'RedHat',
+        :lsbmajdistrelease => '6',
+      }
+    }
+    let(:params) { { :content => true } }
+
+    it 'should fail' do
+      expect {
+        should contain_class('rsyslog')
+      }.to raise_error(Puppet::Error)
+    end
+  end
+
+  context 'with ensure specified as absent' do
+    let(:title) { 'example' }
+    let(:facts) {
+      { :osfamily          => 'RedHat',
+        :lsbmajdistrelease => '6',
+      }
+    }
+    let(:params) { { :ensure => 'absent' } }
+
+    it { should contain_class('rsyslog') }
+
+    it {
+      should contain_file('/etc/rsyslog.d/example.conf').with({
+        'ensure'  => 'absent',
+        'owner'   => 'root',
+        'group'   => 'root',
+        'mode'    => '0644',
+        'require' => 'Common::Mkdir_p[/etc/rsyslog.d]',
+      })
+    }
+  end
+
+  context 'with ensure specified as invalid value' do
+    let(:title) { 'example' }
+    let(:facts) {
+      { :osfamily          => 'RedHat',
+        :lsbmajdistrelease => '6',
+      }
+    }
+    let(:params) { { :ensure => 'true' } }
+
+    it 'should fail' do
+      expect {
+        should contain_class('rsyslog')
+      }.to raise_error(Puppet::Error)
+    end
+  end
+end

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -34,7 +34,6 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
 
-
 #### RULES ####
 
 # Local Logging
@@ -69,6 +68,9 @@ local7.*                                                /var/log/boot.log
 
 # use the local RuleSet as default if not specified otherwise
 $DefaultRuleset local
+
+# Include all config files in /etc/rsyslog.d/
+$IncludeConfig /etc/rsyslog.d/*.conf
 
 <% if @remote_logging_real == 'true' -%>
 # An on-disk queue is created for this action. If the remote host is


### PR DESCRIPTION
This pattern is very convenient when for example sending logs to multiple remote locations.

Module tested on el5 (rsyslog-3.22.1), el6 (rsyslog-5.8.10) and Suse11 (rsyslog-5.10.1)
