### PR TITLE
add support for rsyslog v2 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This module has been tested to work on the following systems with Puppet v3.x an
  * EL 6
  * Suse 11
 
+Older EL 5 and Suse 10/11 systems ships with rsyslog v2.x only. Use rsyslog_conf_version to support them.
+
 ===
 
 # Parameters #
@@ -173,6 +175,13 @@ remote_logging
 Whether to send logs remotely to a centralized logging service.
 
 - *Default*: 'false'
+
+rsyslog_conf_version
+--------------------
+Format version of rsyslog.conf file format. Valid values are '2' and '3'.
+Use version 3 for rsyslog 3 and above. Version 2 format is only supported for clients.
+
+- *Default*: '3'
 
 rsyslog_d_dir
 -------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class rsyslog (
   $log_dir_mode             = '0750',
   $remote_template          = '%HOSTNAME%/%$YEAR%-%$MONTH%-%$DAY%.log',
   $remote_logging           = 'false',
+  $rsyslog_conf_version     = '3',
   $rsyslog_d_dir            = '/etc/rsyslog.d',
   $rsyslog_d_dir_owner      = 'root',
   $rsyslog_d_dir_group      = 'root',
@@ -61,6 +62,8 @@ class rsyslog (
   }
 
   validate_absolute_path($rsyslog_d_dir)
+
+  validate_re($rsyslog_conf_version, '^(2)|(3)$', "rsyslog_conf_version only knows <2> and <3> as valid values and you have specified <${rsyslog_conf_version}>")
 
   case $::osfamily {
     'RedHat': {

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -1,11 +1,12 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
 
-#rsyslog v3 config file
+#rsyslog v<%= @rsyslog_conf_version %> config file
 
 # if you experience problems, check
 # http://www.rsyslog.com/troubleshoot for assistance
 
+<% if @rsyslog_conf_version != '2' -%>
 #### MODULES ####
 
 $ModLoad imuxsock.so	# provides support for local system logging (e.g. via logger command)
@@ -25,20 +26,27 @@ $ModLoad imtcp.so
 $template RemoteHost, "<%= @log_dir %>/<%= @remote_template %>"
 <% end -%>
 
+<% end -%>
 #### GLOBAL DIRECTIVES ####
 
 # Use default timestamp format
+<% if @rsyslog_conf_version == '2' -%>
+$template TraditionalFormat,"%timegenerated% %HOSTNAME% %syslogtag%%msg:::drop-last-lf%0"
+<% else -%>
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
 # File syncing capability is disabled by default. This feature is usually not required,
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
+<% end -%>
 
 #### RULES ####
 
+<% if @rsyslog_conf_version != '2' -%>
 # Local Logging
 $RuleSet local
 
+<% end -%>
 # Log all kernel messages to the console.
 # Logging much else clutters up the screen.
 #kern.*                                                 /dev/console
@@ -66,13 +74,16 @@ uucp,news.crit                                          /var/log/spooler
 # Save boot messages also to boot.log
 local7.*                                                /var/log/boot.log
 
+<% if @rsyslog_conf_version != '2' -%>
 # use the local RuleSet as default if not specified otherwise
 $DefaultRuleset local
 
 # Include all config files in /etc/rsyslog.d/
 $IncludeConfig /etc/rsyslog.d/*.conf
 
+<% end -%>
 <% if @remote_logging_real == 'true' -%>
+<% if @rsyslog_conf_version != '2' -%>
 # An on-disk queue is created for this action. If the remote host is
 # down, messages are spooled to disk and sent when it is up again.
 $WorkDirectory <%= @spool_dir %> # where to place spool files
@@ -81,8 +92,10 @@ $ActionQueueMaxDiskSpace <%= @max_spool_size %> # 1gb space limit (use as much a
 $ActionQueueSaveOnShutdown on # save messages to disk on shutdown
 $ActionQueueType LinkedList   # run asynchronously
 $ActionResumeRetryCount -1    # infinite retries if host is down
+<% end -%>
 <%= @source_facilities %> <% if @transport_protocol == 'tcp' -%>@<% end -%>@<%= @log_server -%>:<%= @log_server_port %>
 <% end -%>
+<% if @rsyslog_conf_version != '2' -%>
 
 <% if @is_log_server == 'true' -%>
 # logging from remote
@@ -101,5 +114,6 @@ $InputTCPServerRun 514
 $InputUDPServerBindRuleset remote
 # activate it
 $UDPServerRun 514
+<% end -%>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
add support for old clients using rsyslog v2. Like RedHat 5.4 and earlier or Suse 10.

It replace https://github.com/ghoneycutt/puppet-module-rsyslog/pull/44 where GH said:
instead of two templates for the same file, there should be conditional logic within the template.
Also, could you do a validate_re() on $rsyslog_conf_version to ensure it is '2' or '3'.
Oh yea, would also add a note about this to the Compatibility section of the README.
