### PR TITLE
add mail_default_enable param

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,12 @@ List of source facilities to be sent to remote log server. Only used if remote_l
 
 - *Default*: `*.*`
 
+mail_default_enable
+-----------------
+Log mail.* to /var/log/maillog
+
+- *Default*: true
+
 ===
 
 # rsyslog::fragment define #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,7 @@ class rsyslog (
   $enable_udp_server        = undef,
   $kernel_target            = '/var/log/messages',
   $source_facilities        = '*.*',
+  $mail_default_enable      = 'true',
 ) {
 
   # validation

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -51,8 +51,10 @@ kern.*                                                  <%= @kernel_target %>
 # The authpriv file has restricted access.
 authpriv.*                                              /var/log/secure
 
+<% if @mail_default_enable == 'true' -%>
 # Log all the mail messages in one place.
 mail.*                                                  -/var/log/maillog
+<% end -%>
 
 # Log cron stuff
 cron.*                                                  /var/log/cron


### PR DESCRIPTION
This adds a "mail_default_enable" param which defaults to true which is typical for most deployments.  I know this likely needs test updates as well but I wanted initial feedback on this option.  It's a necessary parameter for my environment.
