### PR TITLE
add support for rsyslog v2 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ Whether to send logs remotely to a centralized logging service.
 
 - *Default*: 'false'
 
+rsyslog_conf_version
+--------------------
+Format version of rsyslog.conf file format. Supported are version 2 (clients only) and 3. 'USE_DEFAULTS' will choose the version based on the installed package version. Valid values are '2' '3' and 'USE_DEFAULTS'.
+
+- *Default*: 'USE_DEFAULTS'
+
 rsyslog_d_dir
 -------------
 Path to place rsyslog.d files.

--- a/lib/facter/rsyslog_version.rb
+++ b/lib/facter/rsyslog_version.rb
@@ -1,0 +1,11 @@
+# rsyslog_version.rb
+
+Facter.add("rsyslog_version") do
+  setcode do
+    test_exists = "rsyslogd -v 2>&1 >/dev/null ; echo $?"
+    if Facter::Util::Resolution.exec(test_exists) == '0'
+      cmd = "rsyslogd -v | grep -Eo [0-9]+\.[0-9]+\.[0-9]+"
+      response = Facter::Util::Resolution.exec(cmd)
+    end
+  end
+end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,7 @@ class rsyslog (
   $log_dir_mode             = '0750',
   $remote_template          = '%HOSTNAME%/%$YEAR%-%$MONTH%-%$DAY%.log',
   $remote_logging           = 'false',
+  $rsyslog_conf_version     = 'USE_DEFAULTS',
   $rsyslog_d_dir            = '/etc/rsyslog.d',
   $rsyslog_d_dir_owner      = 'root',
   $rsyslog_d_dir_group      = 'root',
@@ -54,6 +55,23 @@ class rsyslog (
   # validation
   if $source_facilities == '' {
     fail('rsyslog::source_facilities cannot be empty!')
+  }
+
+  case $rsyslog_conf_version {
+    'USE_DEFAULTS': {
+      case versioncmp($::rsyslog_version, 3) {
+        '0','1': {
+          $rsyslog_conf_version_real = '3'
+        }
+        default: {
+          $rsyslog_conf_version_real = '2'
+        }
+      }
+    }
+    default: {
+      validate_re($rsyslog_conf_version, '^(2)|(3)$', "rsyslog_conf_version only knows <2>, <3> and <USE_DEFAULTS> as valid values and you have specified <${rsyslog_conf_version}>.")
+      $rsyslog_conf_version_real = $rsyslog_conf_version
+    }
   }
 
   if $rsyslog_fragments != undef {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,6 +7,7 @@ describe 'rsyslog' do
         :osfamily          => 'RedHat',
         :lsbmajdistrelease => '6',
         :domain            => 'defaultdomain',
+        :rsyslog_version   => '5.8.10',
       }
     end
 
@@ -28,6 +29,7 @@ describe 'rsyslog' do
     context 'rsyslog config content' do
       context 'with default params' do
         it { should contain_file('rsyslog_config').with_content(/^kern.\*\s+\/var\/log\/messages$/) }
+        it { should contain_file('rsyslog_config').with_content(/^#rsyslog v3 config file$/) }
 
         it { should_not contain_file('rsyslog_config').with_content(/^\$ModLoad imudp.so$/) }
         it { should_not contain_file('rsyslog_config').with_content(/^\$ModLoad imtcp.so$/) }
@@ -215,6 +217,50 @@ describe 'rsyslog' do
             should contain_file('rsyslog_config') \
             .with_content(/^\$template RemoteHost, "\/foo\/bar\/%HOSTNAME%.log"$/)
 	}
+        end
+
+        context 'with rsyslog_conf_version=2 specified' do
+          let :params do
+            {
+              :rsyslog_conf_version => '2',
+            }
+          end
+          it { should contain_file('rsyslog_config').with_content(/^#rsyslog v2 config file$/) }
+          it { should contain_file('rsyslog_config').with_content(/^\$template TraditionalFormat,\"%timegenerated% %HOSTNAME% %syslogtag%%msg:::drop-last-lf%0\"$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$ModLoad imuxsock.so	# provides support for local system logging (e.g. via logger command)/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$ModLoad imklog.so	# provides kernel logging support (previously done by rklogd)/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$ModLoad imudp.so$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$ModLoad imtcp.so$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$template RemoteHost, "\/srv\/logs\/%HOSTNAME%\/%\$YEAR%-%\$MONTH%-%\$DAY%.log"$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$RuleSet local$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$DefaultRuleset local$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$IncludeConfig \/etc\/rsyslog.d\/*.conf$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$WorkDirectory \/var\/spool\/rsyslog # where to place spool files$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$ActionQueueFileName queue # unique name prefix for spool files$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$ActionQueueMaxDiskSpace 1g # 1gb space limit \(use as much as possible\)$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$ActionQueueSaveOnShutdown on # save messages to disk on shutdown$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$ActionQueueType LinkedList   # run asynchronously$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$ActionResumeRetryCount -1    # infinite retries if host is down$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\*.\* @@log.defaultdomain:514/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$RuleSet remote\n\*.\*?RemoteHost$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$InputTCPServerBindRuleset remote$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$InputTCPServerRun 514$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$InputUDPServerBindRuleset remote$/) }
+          it { should_not contain_file('rsyslog_config').with_content(/^\$UDPServerRun 514$/) }
+        end
+
+        context 'with rsyslog_conf_version specified as invalid value' do
+          let :params do
+            {
+              :rsyslog_conf_version => 'invalid',
+            }
+          end
+          it do
+            expect {
+              should contain_class('rsyslog')
+            }.to raise_error(Puppet::Error,/^rsyslog_conf_version only knows <2>, <3> and <USE_DEFAULTS> as valid values and you have specified <invalid>/)
+          end
         end
      end
  end

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -1,11 +1,12 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
 
-#rsyslog v3 config file
+#rsyslog v<%= @rsyslog_conf_version_real %> config file
 
 # if you experience problems, check
 # http://www.rsyslog.com/troubleshoot for assistance
 
+<% if @rsyslog_conf_version_real != '2' -%>
 #### MODULES ####
 
 $ModLoad imuxsock.so	# provides support for local system logging (e.g. via logger command)
@@ -25,20 +26,27 @@ $ModLoad imtcp.so
 $template RemoteHost, "<%= @log_dir %>/<%= @remote_template %>"
 <% end -%>
 
+<% end -%>
 #### GLOBAL DIRECTIVES ####
 
 # Use default timestamp format
+<% if @rsyslog_conf_version_real == '2' -%>
+$template TraditionalFormat,"%timegenerated% %HOSTNAME% %syslogtag%%msg:::drop-last-lf%0"
+<% else -%>
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
 # File syncing capability is disabled by default. This feature is usually not required,
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
+<% end -%>
 
 #### RULES ####
 
+<% if @rsyslog_conf_version_real != '2' -%>
 # Local Logging
 $RuleSet local
 
+<% end -%>
 # Log all kernel messages to the console.
 # Logging much else clutters up the screen.
 #kern.*                                                 /dev/console
@@ -66,13 +74,16 @@ uucp,news.crit                                          /var/log/spooler
 # Save boot messages also to boot.log
 local7.*                                                /var/log/boot.log
 
+<% if @rsyslog_conf_version_real != '2' -%>
 # use the local RuleSet as default if not specified otherwise
 $DefaultRuleset local
 
 # Include all config files in /etc/rsyslog.d/
 $IncludeConfig /etc/rsyslog.d/*.conf
 
+<% end -%>
 <% if @remote_logging_real == 'true' -%>
+<% if @rsyslog_conf_version_real != '2' -%>
 # An on-disk queue is created for this action. If the remote host is
 # down, messages are spooled to disk and sent when it is up again.
 $WorkDirectory <%= @spool_dir %> # where to place spool files
@@ -81,8 +92,10 @@ $ActionQueueMaxDiskSpace <%= @max_spool_size %> # 1gb space limit (use as much a
 $ActionQueueSaveOnShutdown on # save messages to disk on shutdown
 $ActionQueueType LinkedList   # run asynchronously
 $ActionResumeRetryCount -1    # infinite retries if host is down
+<% end -%>
 <%= @source_facilities %> <% if @transport_protocol == 'tcp' -%>@<% end -%>@<%= @log_server -%>:<%= @log_server_port %>
 <% end -%>
+<% if @rsyslog_conf_version_real != '2' -%>
 
 <% if @is_log_server == 'true' -%>
 # logging from remote
@@ -101,5 +114,6 @@ $InputTCPServerRun 514
 $InputUDPServerBindRuleset remote
 # activate it
 $UDPServerRun 514
+<% end -%>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
adds support for rsyslog v2.x clients like RHEL 5.4 and Suse 10.
It can choose the used version based on the installed rsyslog package. Alternatively it can be set via hiera.

This replaces https://github.com/ghoneycutt/puppet-module-rsyslog/pull/45
