### PR TITLE
Do not set SYSLOGD_OPTIONS on EL6

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -994,7 +994,7 @@ describe 'rsyslog' do
           })
         }
         it {
-          should contain_file('rsyslog_sysconfig').with_content(/^SYSLOGD_OPTIONS="-c 4"$/)
+          should contain_file('rsyslog_sysconfig').without_content(/^SYSLOGD_OPTIONS=/)
         }
       end
     end

--- a/templates/sysconfig.rhel6.erb
+++ b/templates/sysconfig.rhel6.erb
@@ -4,4 +4,4 @@
 # Options to syslogd
 # syslogd options are deprecated since rsyslog v3
 # if you want to use them, switch to compatibility mode 2 by "-c 2"
-SYSLOGD_OPTIONS="-c 4"
+#SYSLOGD_OPTIONS=""


### PR DESCRIPTION
This is needed to fix the following error when rsyslog is started.

"Starting system logger: rsyslogd: error: option -c is no longer
supported - ignored"