### PR TITLE
parameterize (r)syslogd startup options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
 
 sudo: false
 
-script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+script: 'bundle exec metadata-json-lint metadata.json && bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
 
 matrix:
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ else
   gem 'puppet', :require => false
 end
 
+gem 'metadata-json-lint'
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'

--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,9 @@ end
 gem 'puppetlabs_spec_helper', '>= 0.1.0'
 gem 'puppet-lint', '>= 1.0.0'
 gem 'facter', '>= 1.7.0'
+gem 'rspec-puppet', '~>1.0'
+
+# rspec must be v2 for ruby 1.8.7
+if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
+  gem 'rspec', '~> 2.0'
+end

--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ Mode of the rsyslog sysconfig config file.
 
 - *Default*: '0644'
 
+syslogd_options
+---------------
+String with startup options to pass to (r)syslogd.
+
+- *Default*: 'USE_DEFAULTS' based on platform
+
 daemon
 ------
 Name of the rsyslog service.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,6 +27,7 @@ class rsyslog (
   $sysconfig_owner          = 'root',
   $sysconfig_group          = 'root',
   $sysconfig_mode           = '0644',
+  $syslogd_options          = 'USE_DEFAULTS',
   $daemon                   = 'USE_DEFAULTS',
   $daemon_ensure            = 'running',
   $daemon_enable            = true,
@@ -152,16 +153,19 @@ class rsyslog (
       $default_sysconfig_path         = '/etc/sysconfig/rsyslog'
       case $::lsbmajdistrelease {
         '5': {
-          $default_pid_file = '/var/run/rsyslogd.pid'
-          $sysconfig_erb    = 'sysconfig.rhel5.erb'
+          $default_pid_file        = '/var/run/rsyslogd.pid'
+          $sysconfig_erb           = 'sysconfig.rhel5.erb'
+          $default_syslogd_options = '-m 0'
         }
         '6': {
-          $default_pid_file = '/var/run/syslogd.pid'
-          $sysconfig_erb    = 'sysconfig.rhel6.erb'
+          $default_pid_file        = '/var/run/syslogd.pid'
+          $sysconfig_erb           = 'sysconfig.rhel6.erb'
+          $default_syslogd_options = ''
         }
         '7': {
-          $default_pid_file = '/var/run/syslogd.pid'
-          $sysconfig_erb    = 'sysconfig.rhel7.erb'
+          $default_pid_file        = '/var/run/syslogd.pid'
+          $sysconfig_erb           = 'sysconfig.rhel7.erb'
+          $default_syslogd_options = '-c 4'
         }
         default: {
           fail("rsyslog supports RedHat like systems with major release of 5, 6 and 7 and you have ${::lsbmajdistrelease}")
@@ -176,11 +180,13 @@ class rsyslog (
       $default_sysconfig_path         = '/etc/default/rsyslog'
       $default_pid_file               = '/var/run/rsyslogd.pid'
       $sysconfig_erb                  = 'sysconfig.debian.erb'
+      $default_syslogd_options        = '-c5'
     }
     'Suse' : {
       $default_logrotate_present      = true
       $default_service_name           = 'syslog'
       $default_sysconfig_path         = '/etc/sysconfig/syslog'
+      $default_syslogd_options        = ''
       $default_pid_file               = '/var/run/rsyslogd.pid'
       case $::lsbmajdistrelease {
         '10' : {
@@ -222,6 +228,12 @@ class rsyslog (
       default        => str2bool($logrotate_present)
     }
   }
+
+  $syslogd_options_real = $syslogd_options ? {
+    'USE_DEFAULTS' => $default_syslogd_options,
+    default        => $syslogd_options
+  }
+  validate_string($syslogd_options_real)
 
   $pid_file_real = $pid_file ? {
     'USE_DEFAULTS' => $default_pid_file,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -923,6 +923,23 @@ describe 'rsyslog' do
   end
 
   describe 'rsyslog_sysconfig' do
+    context 'with syslogd_options specified as invalid type' do
+      let :facts do
+        {
+          :kernel            => 'Linux',
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '7',
+        }
+      end
+      let(:params) { { :syslogd_options => [ 'ar', 'ray' ] } }
+
+      it 'should fail' do
+        expect {
+          should contain_class('rsyslog')
+        }.to raise_error(Puppet::Error,/is not a string.  It looks to be a Array/)
+      end
+    end
+
     context 'on Debian' do
       let :facts do
         {
@@ -944,6 +961,12 @@ describe 'rsyslog' do
         }
 
         it { should contain_file('rsyslog_sysconfig').with_content(/^RSYSLOGD_OPTIONS="-c5"$/) }
+      end
+
+      context 'with syslogd_options specified as valid value' do
+        let(:params) { { :syslogd_options => '-c0' } }
+
+        it { should contain_file('rsyslog_sysconfig').with_content(/^RSYSLOGD_OPTIONS="-c0"$/) }
       end
     end
 
@@ -971,6 +994,12 @@ describe 'rsyslog' do
           should contain_file('rsyslog_sysconfig').with_content(/^SYSLOGD_OPTIONS="-c 4"$/)
         }
       end
+
+      context 'with syslogd_options specified as valid value' do
+        let(:params) { { :syslogd_options => '-c0' } }
+
+        it { should contain_file('rsyslog_sysconfig').with_content(/^SYSLOGD_OPTIONS="-c0"$/) }
+      end
     end
 
     context 'on EL 6' do
@@ -994,8 +1023,14 @@ describe 'rsyslog' do
           })
         }
         it {
-          should contain_file('rsyslog_sysconfig').without_content(/^SYSLOGD_OPTIONS=/)
+          should contain_file('rsyslog_sysconfig').with_content(/^SYSLOGD_OPTIONS=""$/)
         }
+      end
+
+      context 'with syslogd_options specified as valid value' do
+        let(:params) { { :syslogd_options => '-c0' } }
+
+        it { should contain_file('rsyslog_sysconfig').with_content(/^SYSLOGD_OPTIONS="-c0"$/) }
       end
     end
 
@@ -1021,6 +1056,12 @@ describe 'rsyslog' do
         }
         it { should contain_file('rsyslog_sysconfig').with_content(/^SYSLOGD_OPTIONS="-m 0"$/) }
         it { should contain_file('rsyslog_sysconfig').with_content(/^KLOGD_OPTIONS="-x"$/) }
+      end
+
+      context 'with syslogd_options specified as valid value' do
+        let(:params) { { :syslogd_options => '-c0' } }
+
+        it { should contain_file('rsyslog_sysconfig').with_content(/^SYSLOGD_OPTIONS="-c0"$/) }
       end
     end
 
@@ -1050,6 +1091,12 @@ describe 'rsyslog' do
         it { should contain_file('rsyslog_sysconfig').with_content(/^SYSLOG_DAEMON="rsyslogd"$/) }
         it { should contain_file('rsyslog_sysconfig').with_content(/^SYSLOG_NG_CREATE_CONFIG="yes"$/) }
         it { should contain_file('rsyslog_sysconfig').with_content(/^SYSLOG_NG_PARAMS=""$/) }
+      end
+
+      context 'with syslogd_options specified as valid value' do
+        let(:params) { { :syslogd_options => '-c0' } }
+
+        it { should contain_file('rsyslog_sysconfig').with_content(/^SYSLOGD_PARAMS="-c0"$/) }
       end
     end
 
@@ -1082,6 +1129,12 @@ describe 'rsyslog' do
         it { should contain_file('rsyslog_sysconfig').with_content(/^RSYSLOGD_COMPAT_VERSION=""$/) }
         it { should contain_file('rsyslog_sysconfig').with_content(/^RSYSLOGD_PARAMS=""$/) }
       end
+
+      context 'with syslogd_options specified as valid value' do
+        let(:params) { { :syslogd_options => '-c0' } }
+
+        it { should contain_file('rsyslog_sysconfig').with_content(/^SYSLOGD_PARAMS="-c0"$/) }
+      end
     end
 
     context 'on Suse 12' do
@@ -1105,6 +1158,12 @@ describe 'rsyslog' do
           })
         }
         it { should contain_file('rsyslog_sysconfig').with_content(/^RSYSLOGD_PARAMS=""$/) }
+      end
+
+      context 'with syslogd_options specified as valid value' do
+        let(:params) { { :syslogd_options => '-c0' } }
+
+        it { should contain_file('rsyslog_sysconfig').with_content(/^RSYSLOGD_PARAMS="-c0"$/) }
       end
     end
   end

--- a/templates/sysconfig.debian.erb
+++ b/templates/sysconfig.debian.erb
@@ -2,5 +2,5 @@
 # -x disables DNS lookups for remote messages
 # -c compatibility mode
 # See rsyslogd(8) for more details
-RSYSLOGD_OPTIONS="-c5"
+RSYSLOGD_OPTIONS="<%= @syslogd_options_real %>"
 

--- a/templates/sysconfig.rhel5.erb
+++ b/templates/sysconfig.rhel5.erb
@@ -6,7 +6,7 @@
 # -rPortNumber Enables logging from remote machines. The listener will listen to the specified port.
 # -x disables DNS lookups on messages recieved with -r
 # See syslogd(8) for more details
-SYSLOGD_OPTIONS="-m 0"
+SYSLOGD_OPTIONS="<%= @syslogd_options_real %>"
 # Options to klogd
 # -2 prints all kernel oops messages twice; once for klogd to decode, and
 #    once for processing with 'ksymoops'

--- a/templates/sysconfig.rhel6.erb
+++ b/templates/sysconfig.rhel6.erb
@@ -4,4 +4,4 @@
 # Options to syslogd
 # syslogd options are deprecated since rsyslog v3
 # if you want to use them, switch to compatibility mode 2 by "-c 2"
-#SYSLOGD_OPTIONS=""
+SYSLOGD_OPTIONS="<%= @syslogd_options_real %>"

--- a/templates/sysconfig.rhel7.erb
+++ b/templates/sysconfig.rhel7.erb
@@ -4,4 +4,4 @@
 # Options to syslogd
 # syslogd options are deprecated since rsyslog v3
 # if you want to use them, switch to compatibility mode 2 by "-c 2"
-SYSLOGD_OPTIONS="-c 4"
+SYSLOGD_OPTIONS="<%= @syslogd_options_real %>"

--- a/templates/sysconfig.suse10.erb
+++ b/templates/sysconfig.suse10.erb
@@ -3,7 +3,7 @@
 
 KERNEL_LOGLEVEL=1
 
-SYSLOGD_PARAMS=""
+SYSLOGD_PARAMS="<%= @syslogd_options_real %>"
 
 KLOGD_PARAMS="-x"
 

--- a/templates/sysconfig.suse11.erb
+++ b/templates/sysconfig.suse11.erb
@@ -3,7 +3,7 @@
 
 KERNEL_LOGLEVEL=1
 
-SYSLOGD_PARAMS=""
+SYSLOGD_PARAMS="<%= @syslogd_options_real %>"
 
 KLOGD_PARAMS="-x"
 

--- a/templates/sysconfig.suse12.erb
+++ b/templates/sysconfig.suse12.erb
@@ -1,4 +1,4 @@
 # This file is being maintained by Puppet.
 # DO NOT EDIT
 
-RSYSLOGD_PARAMS=""
+RSYSLOGD_PARAMS="<%= @syslogd_options_real %>"


### PR DESCRIPTION
Since release v0.17.2 we get warnings on RH6.6 running rsyslog-5.8.10-10.el6_6 that we hadn't had before:
<pre>
Apr 16 15:07:42 hostname rsyslogd: [origin software="rsyslogd" swVersion="5.8.10" x-pid="20386" x-info="http://www.rsyslog.com"] start
Apr 16 15:07:42 hostname rsyslogd: WARNING: rsyslogd is running in compatibility mode. Automatically generated config directives may interfer with your rsyslog.conf settings. We suggest upgrading your config and adding -c5 as the first rsyslogd option.
Apr 16 15:07:42 hostname rsyslogd: Warning: backward compatibility layer added to following directive to rsyslog.conf: ModLoad immark
Apr 16 15:07:42 hostname rsyslogd: Warning: backward compatibility layer added to following directive to rsyslog.conf: MarkMessagePeriod 1200
Apr 16 15:07:42 hostname rsyslogd: Warning: backward compatibility layer added to following directive to rsyslog.conf: ModLoad imuxsock
</pre>

With this patch it is possible to pass your own startup options for more flexibility. USE_DEFAULT will use the module defaults so it's backward compatible.
