### PR TITLE
Fix configuration error on rsyslog <= v3 systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Boolean to determine whether to send logs remotely to a centralized logging serv
 
 rsyslog_conf_version
 --------------------
-Format version of rsyslog.conf file format. Supported are version 2 (clients only) and 3. 'USE_DEFAULTS' will choose the version based on the installed package version. Valid values are '2' '3' and 'USE_DEFAULTS'.
+Format version of rsyslog.conf file format. Supported are version 2 (clients only), 3, 4 and 5. 'USE_DEFAULTS' will choose the version based on the installed package version.
 
 - *Default*: 'USE_DEFAULTS'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,13 +109,13 @@ class rsyslog (
   # setting default values depending on the running rsyslog version
   # Force puppet to save numbers as integers instead of strings (0 + X)
   # https://tickets.puppetlabs.com/browse/PUP-2735
-  if (versioncmp($::rsyslog_version, '5') >= 0) {
+  if (versioncmp("${::rsyslog_version}", '5') >= 0) { # lint:ignore:only_variable_string
     $default_rsyslog_conf_version = 0 + 5
     $default_emerg_target         = ':omusrmsg:*'
-  } elsif (versioncmp($::rsyslog_version, '4') >= 0) {
+  } elsif (versioncmp("${::rsyslog_version}", '4') >= 0) { # lint:ignore:only_variable_string
     $default_rsyslog_conf_version = 0 + 4
     $default_emerg_target         = '*'
-  } elsif (versioncmp($::rsyslog_version, '3') >= 0) {
+  } elsif (versioncmp("${::rsyslog_version}", '3') >= 0) { # lint:ignore:only_variable_string
     $default_rsyslog_conf_version = 0 + 3
     $default_emerg_target         = '*'
   } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -112,6 +112,9 @@ class rsyslog (
   if (versioncmp($::rsyslog_version, '5') >= 0) {
     $default_rsyslog_conf_version = 0 + 5
     $default_emerg_target         = ':omusrmsg:*'
+  } elsif (versioncmp($::rsyslog_version, '4') >= 0) {
+    $default_rsyslog_conf_version = 0 + 4
+    $default_emerg_target         = '*'
   } elsif (versioncmp($::rsyslog_version, '3') >= 0) {
     $default_rsyslog_conf_version = 0 + 3
     $default_emerg_target         = '*'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -442,6 +442,8 @@ describe 'rsyslog' do
       context "with default params" do
         if value.to_i >= 5
           it { should contain_file('rsyslog_config').with_content(/^#rsyslog v5 config file$/) }
+        elsif value.to_i >= 4
+          it { should contain_file('rsyslog_config').with_content(/^#rsyslog v4 config file$/) }
         elsif value.to_i >= 3
           it { should contain_file('rsyslog_config').with_content(/^#rsyslog v3 config file$/) }
         else value.to_i >= 2
@@ -470,10 +472,14 @@ describe 'rsyslog' do
         it { should contain_file('rsyslog_config').with_content(/^\$DirCreateMode 0700$/) }
 
         #### RULES ####
-        if value.to_i > 2
+        if value.to_i > 3
           it { should contain_file('rsyslog_config').with_content(/^\$RuleSet local$/) }
           it { should contain_file('rsyslog_config').with_content(/^\$DefaultRuleset local$/) }
           it { should contain_file('rsyslog_config').with_content(/^\$IncludeConfig \/etc\/rsyslog.d\/\*.conf$/) }
+        elsif value.to_i > 2
+          it { should contain_file('rsyslog_config').with_content(/^\$IncludeConfig \/etc\/rsyslog.d\/\*.conf$/) }
+          it { should contain_file('rsyslog_config').without_content(/^\$RuleSet local$/) }
+          it { should contain_file('rsyslog_config').without_content(/^\$DefaultRuleset local$/) }
         else
           it { should contain_file('rsyslog_config').without_content(/^\$RuleSet local$/) }
           it { should contain_file('rsyslog_config').without_content(/^\$DefaultRuleset local$/) }

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -59,7 +59,7 @@ $DirCreateMode <%= @dir_create_mode %>
 
 #### RULES ####
 
-<% if @rsyslog_conf_version_real > 2 -%>
+<% if @rsyslog_conf_version_real > 3 -%>
 # Local Logging
 $RuleSet local
 
@@ -68,10 +68,12 @@ $RuleSet local
 <%= log_entry %>
 <% end -%>
 
-<% if @rsyslog_conf_version_real > 2 -%>
+<% if @rsyslog_conf_version_real > 3 -%>
 # use the local RuleSet as default if not specified otherwise
 $DefaultRuleset local
+<% end -%>
 
+<% if @rsyslog_conf_version_real > 2 -%>
 # Include all config files in /etc/rsyslog.d/
 $IncludeConfig /etc/rsyslog.d/*.conf
 


### PR DESCRIPTION
This fixes an configuration error on systems running SLE11.0 and SLE11.1. Error is include below and is caused by "$Ruleset local" and "$DefaultRuleset local".
`````
rsyslogd: invalid or yet-unknown config file command - have you forgotten to load a module?
rsyslogd: the last error occured in /etc/rsyslog.conf, line 28
rsyslogd: invalid or yet-unknown config file command - have you forgotten to load a module?
rsyslogd: the last error occured in /etc/rsyslog.conf, line 58
``````

Tested on the following versions (and their changes):
3.18.3 and 3.22.1:
``````
-# Local Logging
-$RuleSet local
-
 # Log all kernel messages to the console.
 # Logging much else clutters up the screen.
 #kern.*                                                 /dev/console
@@ -54,8 +51,6 @@
 # Save boot messages also to boot.log
 local7.*                                                /var/log/boot.log

-# use the local RuleSet as default if not specified otherwise
-$DefaultRuleset local
``````
4.2.0 and 4.6.2:
``````
-#rsyslog v3 config file
+#rsyslog v4 config file
``````
5.10.1, 5.8.10, 5.8.6, 5.8.7, 7.4.4, 7.4.7, 8.4.0
No changes.