### PR TITLE
Update logic for rsyslog_config

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -512,15 +512,17 @@ class rsyslog (
     }
   }
 
-  file { 'rsyslog_config':
-    ensure  => file,
-    content => template('rsyslog/rsyslog.conf.erb'),
-    path    => $config_path,
-    owner   => $config_owner,
-    group   => $config_group,
-    mode    => $config_mode,
-    require => Package[$package_real],
-    notify  => Service['rsyslog_daemon'],
+  if $::rsyslog_version {
+    file { 'rsyslog_config':
+      ensure  => file,
+      content => template('rsyslog/rsyslog.conf.erb'),
+      path    => $config_path,
+      owner   => $config_owner,
+      group   => $config_group,
+      mode    => $config_mode,
+      require => Package[$package_real],
+      notify  => Service['rsyslog_daemon'],
+    }
   }
 
   common::mkdir_p { $rsyslog_d_dir: }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -315,6 +315,7 @@ describe 'rsyslog' do
             :kernel            => 'Linux',
             :osfamily          => 'RedHat',
             :lsbmajdistrelease => '6',
+            :rsyslog_version   => '5.8.10',
           }
         end
 
@@ -331,6 +332,7 @@ describe 'rsyslog' do
             :kernel            => 'Linux',
             :osfamily          => 'Debian',
             :lsbmajdistrelease => '7',
+            :rsyslog_version   => '7.4.7',
           }
         end
 
@@ -348,6 +350,7 @@ describe 'rsyslog' do
             :kernel            => 'Linux',
             :osfamily          => 'RedHat',
             :lsbmajdistrelease => '5',
+            :rsyslog_version   => '3.22.1',
           }
         end
 
@@ -366,6 +369,7 @@ describe 'rsyslog' do
             :kernel            => 'Linux',
             :osfamily          => 'RedHat',
             :lsbmajdistrelease => '5',
+            :rsyslog_version   => '3.22.1',
           }
         end
 
@@ -405,6 +409,21 @@ describe 'rsyslog' do
           end
         end
       end
+    end
+
+    context 'with fact rsyslog_version empty' do
+      let :facts do
+        {
+          :kernel            => 'Linux',
+          :osfamily          => 'RedHat',
+          :lsbmajdistrelease => '6',
+          :domain            => 'defaultdomain',
+        }
+      end
+
+      it {
+        should_not contain_file('rsyslog_config')
+      }
     end
   end
 
@@ -562,6 +581,7 @@ describe 'rsyslog' do
             :kernel            => 'Linux',
             :osfamily          => 'Debian',
             :lsbmajdistrelease => '7',
+            :rsyslog_version   => '5.8.11',
           }
         end
 
@@ -588,6 +608,7 @@ describe 'rsyslog' do
               :kernel            => 'Linux',
               :osfamily          => 'Debian',
               :lsbmajdistrelease => '7',
+              :rsyslog_version   => '5.8.11',
             }
           end
 


### PR DESCRIPTION
rsyslog_config is now only managed if fact rsyslog_version is set. If
rsyslog_config is managed while $::rsyslog_version is unavailable an
incompatible configuration file might be installed and prevent rsyslog
from logging until next Puppet run when $::rsyslog_version is present.

---
If a different syslog daemon than rsyslog is used on a system running this module there's a good change that rsyslog won't log anything at until the next Puppet run. The fact rsyslog_version isn't populated with any version string in the beginning of the Puppet run because rsyslog is not yet installed. Because of this there's a big chance the configuration file installed won't work with the rsyslog version installed on the system because it falls back to the earliest version available which is 2.

We've seen this on SLE11.1 systems but I'm sure it happens on other operating systems as well.
Proposed solution is to only manage rsyslog_config if rsyslog_version has a value. This will prevent Puppet from installing a configuration file that does not work with the current system's rsyslog version.