### PR TITLE
add mod_imjournal to rsyslog.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,18 @@ The creation mode with which rsyslogd creates new directories.
 
 - *Default*: '0700'
 
+work_directory
+--------------
+The default location for work (spool) files.
+
+- *Default*: '/var/lib/rsyslog'
+
+journalstate_file
+--------------
+The journal state file used by rsyslog.
+
+- *Default*: 'imjournal.state'
+
 ===
 
 # rsyslog::fragment define #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -189,6 +189,7 @@ class rsyslog (
           $default_pid_file        = '/var/run/syslogd.pid'
           $sysconfig_erb           = 'sysconfig.rhel7.erb'
           $default_syslogd_options = '-c 4'
+          $mod_imjournal           = true
         }
         default: {
           fail("rsyslog supports RedHat like systems with major release of 5, 6 and 7 and you have ${::operatingsystemrelease}")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,7 @@ class rsyslog (
   $umask                    = undef,
   $file_create_mode         = '0644',
   $dir_create_mode          = '0700',
-  $working_directory        = '/var/lib/rsyslog',
+  $work_directory           = '/var/lib/rsyslog',
   $journalstate_file        = 'imjournal.state',
 ) {
 
@@ -170,7 +170,7 @@ class rsyslog (
   validate_absolute_path($rsyslog_d_dir)
   validate_re($daemon_ensure, '^(running|stopped)$', "daemon_ensure may be either 'running' or 'stopped' and is set to <${daemon_ensure}>.")
   validate_absolute_path($kernel_target)
-  validate_absolute_path($working_directory)
+  validate_absolute_path($work_directory)
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -171,6 +171,7 @@ class rsyslog (
   validate_re($daemon_ensure, '^(running|stopped)$', "daemon_ensure may be either 'running' or 'stopped' and is set to <${daemon_ensure}>.")
   validate_absolute_path($kernel_target)
   validate_absolute_path($work_directory)
+  validate_string($journalstate_file)
 
   case $::osfamily {
     'RedHat': {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,6 +64,8 @@ class rsyslog (
   $umask                    = undef,
   $file_create_mode         = '0644',
   $dir_create_mode          = '0700',
+  $working_directory        = '/var/lib/rsyslog',
+  $journalstate_file        = 'imjournal.state',
 ) {
 
   # validation
@@ -168,6 +170,7 @@ class rsyslog (
   validate_absolute_path($rsyslog_d_dir)
   validate_re($daemon_ensure, '^(running|stopped)$', "daemon_ensure may be either 'running' or 'stopped' and is set to <${daemon_ensure}>.")
   validate_absolute_path($kernel_target)
+  validate_absolute_path($working_directory)
 
   case $::osfamily {
     'RedHat': {

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -32,6 +32,11 @@ $template RemoteHost, "<%= @log_dir %>/<%= @remote_template %>"
 <% end -%>
 #### GLOBAL DIRECTIVES ####
 
+<% if @mod_imjournal.to_s == 'true' -%>
+# Where to place auxilliary files
+$WorkDirectory <%= @working_directory %>
+<% end -%>
+
 # Use default timestamp format
 <% if @rsyslog_conf_version_real == 2 -%>
 $template TraditionalFormat,"%timegenerated% %HOSTNAME% %syslogtag%%msg:::drop-last-lf%0"
@@ -42,6 +47,16 @@ $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 # not useful and an extreme performance hit
 #$ActionFileEnableSync on
 <% end -%>
+
+<% if @mod_imjournal.to_s == 'true' -%>
+# Turn off message reception via local log socket;
+# local messages are retrieved through imjournal now.
+$OmitLocalLogging on
+
+# File to store the position in the journal
+$IMJournalStateFile <%= @journalstate_file %>
+<% end -%>
+
 <% if @use_tls_real.to_s == 'true' -%>
 
 $DefaultNetstreamDriverCAFile <%= @ca_file %> # trust these CAs

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -11,6 +11,9 @@
 
 $ModLoad imuxsock.so	# provides support for local system logging (e.g. via logger command)
 $ModLoad imklog.so	# provides kernel logging support (previously done by rklogd)
+<% if @mod_imjournal.to_s == 'true' -%>
+$ModLoad imjournal # provides access to the systemd journal
+<% end -%>
 #$ModLoad immark.so	# provides --MARK-- message capability
 
 <% if @is_log_server_real.to_s == 'true' -%>

--- a/templates/rsyslog.conf.erb
+++ b/templates/rsyslog.conf.erb
@@ -34,7 +34,7 @@ $template RemoteHost, "<%= @log_dir %>/<%= @remote_template %>"
 
 <% if @mod_imjournal.to_s == 'true' -%>
 # Where to place auxilliary files
-$WorkDirectory <%= @working_directory %>
+$WorkDirectory <%= @work_directory %>
 <% end -%>
 
 # Use default timestamp format


### PR DESCRIPTION
For EL7, the ```imjournal``` module should be loaded in rsyslog.conf.