### PR TITLE
Use full path to /sbin/service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -415,7 +415,7 @@ class rsyslog (
                                             'create 640 root root',
                                             'sharedscripts',
                                             'postrotate',
-                                            '   /sbin/service syslog reload > /dev/null',
+                                            '    /sbin/service syslog reload > /dev/null',
                                             'endscript',
                                           ]
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -415,7 +415,7 @@ class rsyslog (
                                             'create 640 root root',
                                             'sharedscripts',
                                             'postrotate',
-                                            '    service syslog reload > /dev/null',
+                                            '   /sbin/service syslog reload > /dev/null',
                                             'endscript',
                                           ]
       }

--- a/spec/fixtures/logrotate.suse10
+++ b/spec/fixtures/logrotate.suse10
@@ -31,6 +31,6 @@
     create 640 root root
     sharedscripts
     postrotate
-        service syslog reload > /dev/null
+        /sbin/service syslog reload > /dev/null
     endscript
 }

--- a/spec/fixtures/logrotate.suse11
+++ b/spec/fixtures/logrotate.suse11
@@ -31,6 +31,6 @@
     create 640 root root
     sharedscripts
     postrotate
-        service syslog reload > /dev/null
+        /sbin/service syslog reload > /dev/null
     endscript
 }

--- a/spec/fixtures/logrotate.suse12
+++ b/spec/fixtures/logrotate.suse12
@@ -31,6 +31,6 @@
     create 640 root root
     sharedscripts
     postrotate
-        service syslog reload > /dev/null
+        /sbin/service syslog reload > /dev/null
     endscript
 }


### PR DESCRIPTION
We have found that syslog isn't reloaded when /etc/cron.daily/logrotate is run on SuSE11 systems., leaving us with an empty /var/log/messages.  Empirival tests have shown that harcoding the path fixes the problem.
For the sake of consistency and simplicity this pull request will also apply on SuSE10 and suSE12, although it isn't really neccesary.
