### PR TITLE
Removing dependencies for sysklogd

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -65,6 +65,7 @@
     }
   ],
   "dependencies": [
+    {"name":"ghoneycutt/sysklogd","version_requirement":">= 1.0.0 < 2.0.0"},
     {"name":"ghoneycutt/common","version_requirement":">= 1.6.0 < 2.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.6.0 < 6.0.0"}
   ]


### PR DESCRIPTION
As sysklogd module is only useful for EL5 and this version is no longer actively developed, I suggest to drop the mandatory requirement to the module removing this package