### PR TITLE
Fix spec tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache: bundler
 before_install:
   - bundle -v
   - rm Gemfile.lock || true
-  - gem update --system
+  - if ! [ "$PUPPET_GEM_VERSION" = "~> 3" -o "$PUPPET_GEM_VERSION" = "~> 4" ]; then gem update --system; fi
   - gem update bundler
   - gem --version
   - bundle -v
@@ -20,18 +20,6 @@ script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
 matrix:
   fast_finish: true
   include:
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 1.8.7
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3"
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 3"
   - rvm: 2.1.9

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ else
 end
 
 gem 'facter', '>= 1.7.0', :require => false
-gem 'rspec-puppet', '>= 2.4.0', :require => false
+gem 'rspec-puppet', '~> 2.7.0', :require => false
 gem 'puppet-lint', '~> 2.0', :require => false
 gem 'puppet-lint-absolute_classname-check', :require => false
 gem 'puppet-lint-alias-check', :require => false
@@ -28,7 +28,10 @@ gem 'json_pure', '<= 2.0.1', :require => false        if RUBY_VERSION < '2.0.0'
 gem 'metadata-json-lint',     '0.0.11'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
 gem 'metadata-json-lint',     '1.0.0'    if RUBY_VERSION >= '1.9' && RUBY_VERSION < '2.0'
 gem 'metadata-json-lint' if RUBY_VERSION >= '2.0'
+gem 'public_suffix',      '~> 1.1.0' if RUBY_VERSION < '2.1.1' && RUBY_VERSION >= '1.9'
+gem 'public_suffix',      '1.3.0'    if RUBY_VERSION < '1.9'
 
 gem 'puppetlabs_spec_helper', '2.0.2',    :require => false if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
-gem 'puppetlabs_spec_helper', '>= 2.0.0', :require => false if RUBY_VERSION >= '1.9'
+gem 'puppetlabs_spec_helper', '~> 2.7',   :require => false if RUBY_VERSION >= '1.9'
 gem 'parallel_tests',         '<= 2.9.0', :require => false if RUBY_VERSION < '2.0.0'
+gem 'parallel',               '1.3.3.1',  :require => false if RUBY_VERSION < '1.9'

--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -7,7 +7,7 @@ define rsyslog::fragment (
   $content = undef,
 ) {
 
-  include ::rsyslog
+  include rsyslog
 
   validate_re($ensure, ['file','absent'])
   validate_string($content)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -207,7 +207,7 @@ class rsyslog (
         }
       }
       # ensures that sysklogd is absent, which is needed on EL5
-      require '::sysklogd'
+      require 'sysklogd'
     }
     'Debian': {
       $default_logrotate_present = true
@@ -495,7 +495,7 @@ class rsyslog (
     # logging servers do not log elsewhere
     $remote_logging_real = false
 
-    include ::common
+    include common
 
     common::mkdir_p { $log_dir: }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -344,7 +344,7 @@ describe 'rsyslog' do
         it do
           expect {
             should contain_class('rsyslog')
-          }.to raise_error(Puppet::Error)
+          }.to raise_error(Puppet::Error,/is not an absolute path/)
         end
       end
 
@@ -940,7 +940,7 @@ describe 'rsyslog' do
         it do
           expect {
             should contain_class('rsyslog')
-          }.to raise_error(Puppet::Error)
+          }.to raise_error(Puppet::Error,/is not an absolute path/)
         end
       end
     end
@@ -1228,7 +1228,7 @@ describe 'rsyslog' do
         it 'should fail' do
           expect {
             should contain_class('rsyslog')
-          }.to raise_error(Puppet::Error)
+          }.to raise_error(Puppet::Error,/is not an absolute path/)
         end
       end
 
@@ -1264,7 +1264,7 @@ describe 'rsyslog' do
         it 'should fail' do
           expect {
             should contain_class('rsyslog')
-          }.to raise_error(Puppet::Error)
+          }.to raise_error(Puppet::Error,/str2bool\(\)/)
         end
       end
     end

--- a/spec/defines/fragment_spec.rb
+++ b/spec/defines/fragment_spec.rb
@@ -40,7 +40,7 @@ describe 'rsyslog::fragment' do
     it 'should fail' do
       expect {
         should contain_class('rsyslog')
-      }.to raise_error(Puppet::Error)
+      }.to raise_error(Puppet::Error,/is not a string/)
     end
   end
 
@@ -67,7 +67,7 @@ describe 'rsyslog::fragment' do
       it 'should fail' do
         expect {
           should contain_class('rsyslog')
-        }.to raise_error(Puppet::Error)
+        }.to raise_error(Puppet::Error,/does not match ..file., .absent/)
       end
     end
   end


### PR DESCRIPTION
This patch does stop testing Puppet 3 on Ruby versions prior to 2.1.9.
Ruby 1.8.7 seems to be unsupported by Travis these days :(
Ruby 1.9.3/2.0.0 and puppet-lint do produce conflicting error messages regarding absolute and relative naming of classes.

Beside the above mentioned, there had been only minor changes to the tests.
